### PR TITLE
Fix CPHF tests on dpnp backend without numpy<->dpnp promotion

### DIFF
--- a/gpu4pyscf/cupy/__init__.py
+++ b/gpu4pyscf/cupy/__init__.py
@@ -250,6 +250,12 @@ else:
 
     def _dpnp_get(self, order='C'):
         host = self.asnumpy()
+        # Preserve 0-d arrays: np.ascontiguousarray / asfortranarray force
+        # ndim >= 1, turning a scalar `array(5)` into `array([5])`. CuPy's
+        # .get() keeps the 0-d shape, and downstream code (e.g. using the
+        # result as a reshape dimension) relies on it being a scalar index.
+        if host.ndim == 0:
+            return host
         if order == 'C':
             return np.ascontiguousarray(host)
         if order == 'F':

--- a/gpu4pyscf/scf/tests/test_cphf.py
+++ b/gpu4pyscf/scf/tests/test_cphf.py
@@ -83,8 +83,8 @@ class KnownValues(unittest.TestCase):
         s1vo = cupy.asarray(s1vo)
         mo1_gpu, e1_gpu = cphf_gpu.solve(fx_gpu, mo_energy, mo_occ, h1vo, s1vo, tol=1e-9)
 
-        assert cupy.linalg.norm(mo1_cpu - mo1_gpu.get()) < 1e-6
-        assert cupy.linalg.norm(e1_cpu - e1_gpu.get()) < 1e-6
+        assert numpy.linalg.norm(mo1_cpu - mo1_gpu.get()) < 1e-6
+        assert numpy.linalg.norm(e1_cpu - e1_gpu.get()) < 1e-6
 
     def test_cphf_with_guess(self):
         # Test GPU CPHF solver with an initial guess (mo10) against CPU default
@@ -127,8 +127,8 @@ class KnownValues(unittest.TestCase):
         
         mo1_gpu, e1_gpu = cphf_gpu.solve(fx_gpu, mo_energy, mo_occ, h1vo_gpu, s1vo_gpu, tol=1e-9, mo10=mo10_gpu)
 
-        assert cupy.linalg.norm(mo1_cpu - mo1_gpu.get()) < 1e-6
-        assert cupy.linalg.norm(e1_cpu - e1_gpu.get()) < 1e-6
+        assert numpy.linalg.norm(mo1_cpu - mo1_gpu.get()) < 1e-6
+        assert numpy.linalg.norm(e1_cpu - e1_gpu.get()) < 1e-6
 
     def test_ucphf(self):
         mf = scf.UHF(mol)
@@ -166,10 +166,10 @@ class KnownValues(unittest.TestCase):
         s1vo = cupy.asarray(s1vo)
         mo1_gpu, e1_gpu = ucphf_gpu.solve(fx_gpu, mo_energy, mo_occ, h1vo, s1vo, tol=1e-9)
 
-        assert cupy.linalg.norm(mo1_cpu[0] - mo1_gpu[0].get()) < 1e-6
-        assert cupy.linalg.norm(mo1_cpu[1] - mo1_gpu[1].get()) < 1e-6
-        assert cupy.linalg.norm(e1_cpu[0] - e1_gpu[0].get()) < 1e-6
-        assert cupy.linalg.norm(e1_cpu[1] - e1_gpu[1].get()) < 1e-6
+        assert numpy.linalg.norm(mo1_cpu[0] - mo1_gpu[0].get()) < 1e-6
+        assert numpy.linalg.norm(mo1_cpu[1] - mo1_gpu[1].get()) < 1e-6
+        assert numpy.linalg.norm(e1_cpu[0] - e1_gpu[0].get()) < 1e-6
+        assert numpy.linalg.norm(e1_cpu[1] - e1_gpu[1].get()) < 1e-6
 
 if __name__ == "__main__":
     print("Full Tests for CPHF/UCPHF")


### PR DESCRIPTION
test_cphf.py compared host arrays (mo1_cpu - mo1_gpu.get()) via cupy.linalg.norm, which only works on CuPy because CuPy's norm internally promotes numpy->device. dpnp's linalg.norm rejects bare numpy. Both operands are host numpy, so use numpy.linalg.norm, matching the convention used everywhere else in the test suite.

The shim's .get() (_dpnp_get) returned np.ascontiguousarray(host), which forces ndim>=1 and turned a 0-d scalar array(5) into array([5]), shape (1,). That broke s1.reshape(-1, nmoa, nocca) in ucphf.solve_withs1 (the shape element is no longer a scalar index). CuPy's .get() preserves 0-d rank, so make the shim faithful by returning 0-d results unchanged. This is a device->host shape fix, not a dpnp bug or an array-type promotion.

https://claude.ai/code/session_011vJFAymDEUBmWtVMd6xjEj